### PR TITLE
[SDFAB-1209] Add java options to the atomix/runtime protos

### DIFF
--- a/api/atomix/counter/v1/counter.proto
+++ b/api/atomix/counter/v1/counter.proto
@@ -12,6 +12,9 @@ import "atomix/runtime/v1/descriptor.proto";
 import "atomix/runtime/v1/headers.proto";
 import "gogoproto/gogo.proto";
 
+option java_package = "io.atomix.runtime.counter";
+option java_multiple_files = true;
+
 // Counter is a service for a counter primitive
 service Counter {
     option (atomix.runtime.v1.name) = "Counter";

--- a/api/atomix/counter/v1/manager.proto
+++ b/api/atomix/counter/v1/manager.proto
@@ -12,6 +12,9 @@ import "atomix/runtime/v1/descriptor.proto";
 import "atomix/runtime/v1/headers.proto";
 import "gogoproto/gogo.proto";
 
+option java_package = "io.atomix.runtime.counter";
+option java_multiple_files = true;
+
 // CounterManager is a manager for a counter primitive
 service CounterManager {
     option (atomix.runtime.v1.name) = "Counter";

--- a/api/atomix/election/v1/election.proto
+++ b/api/atomix/election/v1/election.proto
@@ -13,6 +13,9 @@ import "atomix/runtime/v1/headers.proto";
 import "atomix/runtime/v1/object.proto";
 import "gogoproto/gogo.proto";
 
+option java_package = "io.atomix.runtime.election";
+option java_multiple_files = true;
+
 // LeaderElection is a service for a leader election primitive
 service LeaderElection {
     option (atomix.runtime.v1.name) = "LeaderElection";

--- a/api/atomix/election/v1/manager.proto
+++ b/api/atomix/election/v1/manager.proto
@@ -12,6 +12,9 @@ import "atomix/runtime/v1/descriptor.proto";
 import "atomix/runtime/v1/headers.proto";
 import "gogoproto/gogo.proto";
 
+option java_package = "io.atomix.runtime.election";
+option java_multiple_files = true;
+
 // LeaderElectionManager is a manager for a leader election primitive
 service LeaderElectionManager {
     option (atomix.runtime.v1.name) = "LeaderElection";

--- a/api/atomix/indexed_map/v1/indexed_map.proto
+++ b/api/atomix/indexed_map/v1/indexed_map.proto
@@ -14,6 +14,9 @@ import "atomix/runtime/v1/headers.proto";
 import "atomix/runtime/v1/object.proto";
 import "gogoproto/gogo.proto";
 
+option java_package = "io.atomix.runtime.indexedmap";
+option java_multiple_files = true;
+
 // IndexedMap is a service for a sorted/indexed map primitive
 service IndexedMap {
     option (atomix.runtime.v1.name) = "IndexedMap";

--- a/api/atomix/indexed_map/v1/manager.proto
+++ b/api/atomix/indexed_map/v1/manager.proto
@@ -12,6 +12,9 @@ import "atomix/runtime/v1/descriptor.proto";
 import "atomix/runtime/v1/headers.proto";
 import "gogoproto/gogo.proto";
 
+option java_package = "io.atomix.runtime.indexedmap";
+option java_multiple_files = true;
+
 // IndexedMapManager is a manager for an indexed map primitive
 service IndexedMapManager {
     option (atomix.runtime.v1.name) = "IndexedMap";

--- a/api/atomix/list/v1/list.proto
+++ b/api/atomix/list/v1/list.proto
@@ -13,6 +13,9 @@ import "atomix/runtime/v1/headers.proto";
 import "atomix/runtime/v1/object.proto";
 import "gogoproto/gogo.proto";
 
+option java_package = "io.atomix.runtime.list";
+option java_multiple_files = true;
+
 // List is a service for a list primitive
 service List {
     option (atomix.runtime.v1.name) = "List";

--- a/api/atomix/list/v1/manager.proto
+++ b/api/atomix/list/v1/manager.proto
@@ -12,6 +12,9 @@ import "atomix/runtime/v1/descriptor.proto";
 import "atomix/runtime/v1/headers.proto";
 import "gogoproto/gogo.proto";
 
+option java_package = "io.atomix.runtime.list";
+option java_multiple_files = true;
+
 // ListManager is a manager for a list primitive
 service ListManager {
     option (atomix.runtime.v1.name) = "List";

--- a/api/atomix/lock/v1/lock.proto
+++ b/api/atomix/lock/v1/lock.proto
@@ -14,6 +14,9 @@ import "atomix/runtime/v1/headers.proto";
 import "atomix/runtime/v1/object.proto";
 import "gogoproto/gogo.proto";
 
+option java_package = "io.atomix.runtime.lock";
+option java_multiple_files = true;
+
 // Lock is a service for a lock primitive
 service Lock {
     option (atomix.runtime.v1.name) = "Lock";

--- a/api/atomix/lock/v1/manager.proto
+++ b/api/atomix/lock/v1/manager.proto
@@ -12,6 +12,9 @@ import "atomix/runtime/v1/descriptor.proto";
 import "atomix/runtime/v1/headers.proto";
 import "gogoproto/gogo.proto";
 
+option java_package = "io.atomix.runtime.lock";
+option java_multiple_files = true;
+
 // LockManager is a manager for a Lock primitive
 service LockManager {
     option (atomix.runtime.v1.name) = "Lock";

--- a/api/atomix/map/v1/manager.proto
+++ b/api/atomix/map/v1/manager.proto
@@ -12,6 +12,9 @@ import "atomix/runtime/v1/descriptor.proto";
 import "atomix/runtime/v1/headers.proto";
 import "gogoproto/gogo.proto";
 
+option java_package = "io.atomix.runtime.map";
+option java_multiple_files = true;
+
 // MapManager is a manager for a Map primitive
 service MapManager {
     option (atomix.runtime.v1.name) = "Map";

--- a/api/atomix/map/v1/map.proto
+++ b/api/atomix/map/v1/map.proto
@@ -14,6 +14,9 @@ import "atomix/runtime/v1/object.proto";
 import "atomix/runtime/v1/descriptor.proto";
 import "gogoproto/gogo.proto";
 
+option java_package = "io.atomix.runtime.map";
+option java_multiple_files = true;
+
 // Map is a service for a map primitive
 service Map {
     option (atomix.runtime.v1.name) = "Map";

--- a/api/atomix/runtime/v1/descriptor.proto
+++ b/api/atomix/runtime/v1/descriptor.proto
@@ -10,6 +10,9 @@ package atomix.runtime.v1;
 
 import "google/protobuf/descriptor.proto";
 
+option java_package = "io.atomix.runtime";
+option java_multiple_files = true;
+
 extend google.protobuf.ServiceOptions {
     string name = 50000;
     ComponentType component = 50001;

--- a/api/atomix/runtime/v1/headers.proto
+++ b/api/atomix/runtime/v1/headers.proto
@@ -10,6 +10,9 @@ package atomix.runtime.v1;
 
 import "gogoproto/gogo.proto";
 
+option java_package = "io.atomix.runtime";
+option java_multiple_files = true;
+
 message ClusterRequestHeaders {
     string cluster = 1;
 }

--- a/api/atomix/runtime/v1/object.proto
+++ b/api/atomix/runtime/v1/object.proto
@@ -11,6 +11,9 @@ package atomix.runtime.v1;
 import "atomix/runtime/v1/timestamp.proto";
 import "gogoproto/gogo.proto";
 
+option java_package = "io.atomix.runtime";
+option java_multiple_files = true;
+
 message ObjectMeta {
     uint64 revision = 1 [
         (gogoproto.casttype) = "Revision"

--- a/api/atomix/runtime/v1/runtime.proto
+++ b/api/atomix/runtime/v1/runtime.proto
@@ -10,6 +10,9 @@ package atomix.runtime.v1;
 
 import "gogoproto/gogo.proto";
 
+option java_package = "io.atomix.runtime";
+option java_multiple_files = true;
+
 // The runtime service provides control functions for the runtime proxy.
 service Runtime {
     rpc GetRuntimeInfo (GetRuntimeInfoRequest) returns (GetRuntimeInfoResponse);

--- a/api/atomix/runtime/v1/timestamp.proto
+++ b/api/atomix/runtime/v1/timestamp.proto
@@ -11,6 +11,9 @@ package atomix.runtime.v1;
 import "google/protobuf/timestamp.proto";
 import "gogoproto/gogo.proto";
 
+option java_package = "io.atomix.runtime";
+option java_multiple_files = true;
+
 message Timestamp {
     oneof timestamp {
         PhysicalTimestamp physical_timestamp = 1;

--- a/api/atomix/set/v1/manager.proto
+++ b/api/atomix/set/v1/manager.proto
@@ -12,6 +12,9 @@ import "atomix/runtime/v1/descriptor.proto";
 import "atomix/runtime/v1/headers.proto";
 import "gogoproto/gogo.proto";
 
+option java_package = "io.atomix.runtime.set";
+option java_multiple_files = true;
+
 // SetManager is a manager for a Set primitive
 service SetManager {
     option (atomix.runtime.v1.name) = "Set";

--- a/api/atomix/set/v1/set.proto
+++ b/api/atomix/set/v1/set.proto
@@ -13,6 +13,9 @@ import "atomix/runtime/v1/headers.proto";
 import "atomix/runtime/v1/object.proto";
 import "gogoproto/gogo.proto";
 
+option java_package = "io.atomix.runtime.set";
+option java_multiple_files = true;
+
 // Set is a service for a set primitive
 service Set {
     option (atomix.runtime.v1.name) = "Set";

--- a/api/atomix/topic/v1/manager.proto
+++ b/api/atomix/topic/v1/manager.proto
@@ -12,6 +12,9 @@ import "atomix/runtime/v1/descriptor.proto";
 import "atomix/runtime/v1/headers.proto";
 import "gogoproto/gogo.proto";
 
+option java_package = "io.atomix.runtime.topic";
+option java_multiple_files = true;
+
 // TopicManager is a manager for a Topic primitive
 service TopicManager {
     option (atomix.runtime.v1.name) = "Topic";

--- a/api/atomix/topic/v1/topic.proto
+++ b/api/atomix/topic/v1/topic.proto
@@ -13,6 +13,9 @@ import "gogoproto/gogo.proto";
 import "atomix/runtime/v1/headers.proto";
 import "google/protobuf/timestamp.proto";
 
+option java_package = "io.atomix.runtime.topic";
+option java_multiple_files = true;
+
 service Topic {
     option (atomix.runtime.v1.name) = "Topic";
     option (atomix.runtime.v1.component) = PRIMITIVE;

--- a/api/atomix/value/v1/manager.proto
+++ b/api/atomix/value/v1/manager.proto
@@ -12,6 +12,9 @@ import "atomix/runtime/v1/descriptor.proto";
 import "atomix/runtime/v1/headers.proto";
 import "gogoproto/gogo.proto";
 
+option java_package = "io.atomix.runtime.value";
+option java_multiple_files = true;
+
 // ValueManager is a manager for a Value primitive
 service ValueManager {
     option (atomix.runtime.v1.name) = "Value";

--- a/api/atomix/value/v1/value.proto
+++ b/api/atomix/value/v1/value.proto
@@ -13,6 +13,9 @@ import "atomix/runtime/v1/headers.proto";
 import "atomix/runtime/v1/object.proto";
 import "gogoproto/gogo.proto";
 
+option java_package = "io.atomix.runtime.value";
+option java_multiple_files = true;
+
 // Value is a service for a value primitive
 service Value {
     option (atomix.runtime.v1.name) = "Value";


### PR DESCRIPTION
In particular, we specify `java_package` and we split on multiple files