### PR TITLE
Migrate webhook and controllers to use labels rather than annotations for sidecar injection

### DIFF
--- a/controller/examples/deployment.yaml
+++ b/controller/examples/deployment.yaml
@@ -13,7 +13,6 @@ spec:
     metadata:
       labels:
         app: example
-      annotations:
         proxy.atomix.io/inject: "true"
         proxy.atomix.io/profile: example-profile
     spec:

--- a/controller/helm/Chart.yaml
+++ b/controller/helm/Chart.yaml
@@ -7,8 +7,8 @@ name: atomix-runtime-controller
 description: The core Atomix runtime controller implements the Atomix Cloud runtime API
 kubeVersion: ">=1.17.0"
 type: application
-version: 1.6.7
-appVersion: v0.7.7
+version: 1.7.0
+appVersion: v0.8.0
 keywords:
 - atomix
 home: https://atomix.io

--- a/controller/helm/templates/mutatingwebhookconfiguration.yaml
+++ b/controller/helm/templates/mutatingwebhookconfiguration.yaml
@@ -8,12 +8,12 @@ metadata:
   name: {{ template "atomix-runtime-controller.fullname" . }}
 webhooks:
   - name: injector.proxy.atomix.io
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["kube-system"]
+    # Match only pods that opt-in to Atomix with the proxy.atomix.io/inject label
+    objectSelector:
+      matchLabels:
+        proxy.atomix.io/inject: "true"
     rules:
+      # TODO: Support UPDATE operations for pods
       - operations: [ "CREATE" ]
         apiGroups: [ "" ]
         apiVersions: [ "v1" ]

--- a/controller/helm/values.yaml
+++ b/controller/helm/values.yaml
@@ -8,7 +8,7 @@ controller:
   image:
     registry: ""
     repository: atomix/runtime-controller
-    tag: v0.7.7
+    tag: v0.8.0
     pullPolicy: Always
     pullSecrets: []
 
@@ -16,7 +16,7 @@ init:
   image:
     registry: ""
     repository: atomix/runtime-controller-init
-    tag: v0.7.7
+    tag: v0.8.0
     pullPolicy: Always
     pullSecrets: []
 

--- a/controller/pkg/controller/atomix/v3beta3/pod.go
+++ b/controller/pkg/controller/atomix/v3beta3/pod.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -52,24 +53,31 @@ func addPodController(mgr manager.Manager) error {
 		return err
 	}
 
-	// Watch for changes to Profiles
+	// Watch for changes to StorageProfiles and reconcile all Pods in the same namespace
 	err = c.Watch(&source.Kind{Type: &atomixv3beta2.StorageProfile{}}, handler.EnqueueRequestsFromMapFunc(func(object client.Object) []reconcile.Request {
-		podList := &corev1.PodList{}
-		if err := mgr.GetClient().List(context.Background(), podList, &client.ListOptions{Namespace: object.GetNamespace()}); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+
+		pods := &corev1.PodList{}
+		options := &client.ListOptions{
+			Namespace: object.GetNamespace(),
+			LabelSelector: labels.SelectorFromSet(map[string]string{
+				proxyInjectLabel: "true",
+			}),
+		}
+		if err := mgr.GetClient().List(ctx, pods, options); err != nil {
 			log.Error(err)
 			return nil
 		}
 
 		var requests []reconcile.Request
-		for _, pod := range podList.Items {
-			if pod.Annotations[proxyInjectStatusAnnotation] == injectedStatus && pod.Annotations[proxyProfileAnnotation] == object.GetName() {
-				requests = append(requests, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Namespace: pod.Namespace,
-						Name:      pod.Name,
-					},
-				})
-			}
+		for _, pod := range pods.Items {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: pod.Namespace,
+					Name:      pod.Name,
+				},
+			})
 		}
 		return requests
 	}))
@@ -77,24 +85,30 @@ func addPodController(mgr manager.Manager) error {
 		return err
 	}
 
-	// Watch for changes to Stores
+	// Watch for changes to DataStores and reconcile all Pods
 	err = c.Watch(&source.Kind{Type: &atomixv3beta2.DataStore{}}, handler.EnqueueRequestsFromMapFunc(func(object client.Object) []reconcile.Request {
-		podList := &corev1.PodList{}
-		if err := mgr.GetClient().List(context.Background(), podList, &client.ListOptions{}); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+
+		pods := &corev1.PodList{}
+		options := &client.ListOptions{
+			LabelSelector: labels.SelectorFromSet(map[string]string{
+				proxyInjectLabel: "true",
+			}),
+		}
+		if err := mgr.GetClient().List(ctx, pods, options); err != nil {
 			log.Error(err)
 			return nil
 		}
 
 		var requests []reconcile.Request
-		for _, pod := range podList.Items {
-			if pod.Annotations[proxyInjectStatusAnnotation] == injectedStatus {
-				requests = append(requests, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Namespace: pod.Namespace,
-						Name:      pod.Name,
-					},
-				})
-			}
+		for _, pod := range pods.Items {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: pod.Namespace,
+					Name:      pod.Name,
+				},
+			})
 		}
 		return requests
 	}))
@@ -125,7 +139,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, request reconcile.Request
 		return reconcile.Result{}, err
 	}
 
-	profileName, ok := pod.Annotations[proxyProfileAnnotation]
+	profileName, ok := pod.Annotations[proxyProfileLabel]
 	if !ok {
 		return reconcile.Result{}, nil
 	}

--- a/controller/pkg/controller/atomix/v3beta3/pod.go
+++ b/controller/pkg/controller/atomix/v3beta3/pod.go
@@ -139,7 +139,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, request reconcile.Request
 		return reconcile.Result{}, err
 	}
 
-	profileName, ok := pod.Annotations[proxyProfileLabel]
+	profileName, ok := pod.Labels[proxyProfileLabel]
 	if !ok {
 		return reconcile.Result{}, nil
 	}

--- a/controller/pkg/controller/atomix/v3beta3/pod.go
+++ b/controller/pkg/controller/atomix/v3beta3/pod.go
@@ -139,6 +139,10 @@ func (r *PodReconciler) Reconcile(ctx context.Context, request reconcile.Request
 		return reconcile.Result{}, err
 	}
 
+	if pod.Labels == nil {
+		return reconcile.Result{}, nil
+	}
+
 	profileName, ok := pod.Labels[proxyProfileLabel]
 	if !ok {
 		return reconcile.Result{}, nil

--- a/controller/pkg/controller/atomix/v3beta3/proxy.go
+++ b/controller/pkg/controller/atomix/v3beta3/proxy.go
@@ -237,6 +237,9 @@ func (i *ProxyInjector) Handle(ctx context.Context, request admission.Request) a
 	})
 
 	// Add proxy metadata annotations to the Pod.
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
 	pod.Annotations[proxyInjectAnnotation] = injectRuntime
 	pod.Annotations[proxyProfileAnnotation] = profileName
 	pod.Annotations[proxyInjectStatusAnnotation] = injectedStatus

--- a/controller/pkg/controller/atomix/v3beta3/proxy.go
+++ b/controller/pkg/controller/atomix/v3beta3/proxy.go
@@ -32,13 +32,21 @@ const (
 )
 
 const (
-	proxyInjectPath             = "/inject-proxy"
+	proxyInjectPath    = "/inject-proxy"
+	proxyContainerName = "atomix-proxy"
+	configVolumeName   = "atomix-config"
+)
+
+const (
+	proxyProfileAnnotation      = "proxy.atomix.io/profile"
 	proxyInjectAnnotation       = "proxy.atomix.io/inject"
 	proxyInjectStatusAnnotation = "proxy.atomix.io/status"
-	proxyProfileAnnotation      = "proxy.atomix.io/profile"
 	injectedStatus              = "injected"
-	proxyContainerName          = "atomix-proxy"
-	configVolumeName            = "atomix-config"
+)
+
+const (
+	proxyInjectLabel  = "proxy.atomix.io/inject"
+	proxyProfileLabel = "proxy.atomix.io/profile"
 )
 
 const (
@@ -95,31 +103,38 @@ func (i *ProxyInjector) Handle(ctx context.Context, request admission.Request) a
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	injectRuntime, ok := pod.Annotations[proxyInjectAnnotation]
+	// If the proxy.atomix.io/inject label is not present, skip the mutation.
+	injectRuntime, ok := pod.Labels[proxyInjectLabel]
 	if !ok {
-		log.Infof("Skipping proxy injection for Pod '%s'", request.UID)
-		return admission.Allowed(fmt.Sprintf("'%s' annotation not found", proxyInjectAnnotation))
-	}
-	if inject, err := strconv.ParseBool(injectRuntime); err != nil {
-		log.Errorf("Runtime injection failed for Pod '%s'", request.UID, err)
-		return admission.Allowed(fmt.Sprintf("'%s' annotation could not be parsed", proxyInjectAnnotation))
-	} else if !inject {
-		log.Infof("Skipping proxy injection for Pod '%s'", request.UID)
-		return admission.Allowed(fmt.Sprintf("'%s' annotation is false", proxyInjectAnnotation))
+		log.Warnf("Denied proxy injection for Pod '%s': '%s' label was expected but not found", request.UID, proxyInjectLabel)
+		return admission.Allowed(fmt.Sprintf("Denied proxy injection: '%s' label was expected but not found", proxyInjectLabel))
 	}
 
+	// If the proxy.atomix.io/inject label is false, skip the mutation.
+	// TODO: Support removing the sidecar container on updates when proxy.atomix.io/inject label is changed to "false".
+	if inject, err := strconv.ParseBool(injectRuntime); err != nil {
+		log.Warnf("Denied proxy injection for Pod '%s': %s", request.UID, err.Error())
+		return admission.Allowed(fmt.Sprintf("Denied proxy injection: '%s' label could not be parsed", proxyInjectLabel))
+	} else if !inject {
+		log.Debugf("Skipped proxy injection for Pod '%s': '%s' label is false", request.UID, proxyInjectLabel)
+		return admission.Allowed(fmt.Sprintf("Skipped proxy injection: '%s' label is false", proxyInjectLabel))
+	}
+
+	// If the proxy sidecar was already injected, skip mutations.
 	injectedRuntime, ok := pod.Annotations[proxyInjectStatusAnnotation]
 	if ok && injectedRuntime == injectedStatus {
-		log.Infof("Skipping proxy injection for Pod '%s'", request.UID)
-		return admission.Allowed(fmt.Sprintf("'%s' annotation is '%s'", proxyInjectStatusAnnotation, injectedRuntime))
+		log.Debugf("Skipped proxy injection for Pod '%s': '%s' annotation is already '%s'", request.UID, proxyInjectStatusAnnotation, injectedStatus)
+		return admission.Allowed(fmt.Sprintf("Skipped proxy injection: '%s' annotation is already '%s'", proxyInjectStatusAnnotation, injectedStatus))
 	}
 
-	profileName, ok := pod.Annotations[proxyProfileAnnotation]
+	// If the proxy.atomix.io/profile label is missing, skip mutations.
+	profileName, ok := pod.Labels[proxyProfileLabel]
 	if !ok {
-		log.Warnf("No profile specified for Pod '%s'", request.UID)
-		return admission.Denied(fmt.Sprintf("'%s' annotation not found", proxyProfileAnnotation))
+		log.Warnf("Denied proxy injection for Pod '%s': '%s' label was expected but not found", request.UID, proxyProfileLabel)
+		return admission.Denied(fmt.Sprintf("Denied proxy injection: '%s' label was expected but not found", proxyProfileLabel))
 	}
 
+	// Lookup the StorageProfile associated with this Pod.
 	profile := &atomixv3beta2.StorageProfile{}
 	profileNamespacedName := types.NamespacedName{
 		Namespace: request.Namespace,
@@ -127,12 +142,26 @@ func (i *ProxyInjector) Handle(ctx context.Context, request admission.Request) a
 	}
 	if err := i.client.Get(ctx, profileNamespacedName, profile); err != nil {
 		if !k8serrors.IsNotFound(err) {
-			log.Error(err)
+			log.Errorf("Proxy injection failed for Pod '%s'", request.UID, err)
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
-		return admission.Denied(fmt.Sprintf("profile %s not found", profileName))
+		log.Debugf("Denied proxy injection for Pod '%s': StorageProfile '%s' not found", request.UID, profileName)
+		return admission.Denied(fmt.Sprintf("Denied proxy injection: StorageProfile '%s' not found", profileName))
 	}
 
+	// Add the StorageProfile's ConfigMap to the Pod as a volume.
+	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+		Name: configVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: profileName,
+				},
+			},
+		},
+	})
+
+	// Add the sidecar proxy container to the Pod's containers list.
 	pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
 		Name:            proxyContainerName,
 		Image:           getProxyImage(profile.Spec.Proxy.Image),
@@ -206,22 +235,16 @@ func (i *ProxyInjector) Handle(ctx context.Context, request admission.Request) a
 			},
 		},
 	})
-	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
-		Name: configVolumeName,
-		VolumeSource: corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: profileName,
-				},
-			},
-		},
-	})
+
+	// Add proxy metadata annotations to the Pod.
+	pod.Annotations[proxyInjectAnnotation] = injectRuntime
+	pod.Annotations[proxyProfileAnnotation] = profileName
 	pod.Annotations[proxyInjectStatusAnnotation] = injectedStatus
 
 	// Marshal the pod and return a patch response
 	marshaledPod, err := json.Marshal(pod)
 	if err != nil {
-		log.Errorf("Runtime injection failed for Pod '%s'", request.UID, err)
+		log.Errorf("Proxy injection failed for Pod '%s'", request.UID, err)
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 	return admission.PatchResponseFromRaw(request.Object.Raw, marshaledPod)


### PR DESCRIPTION
This PR migrates the runtime controller to use labels for sidecar proxy injection rather than annotations. This allows us to add an `objectSelector` to the `MutatingWebhookConfiguration` to eliminate the sort of chicken-and-egg scenario we've seen in some deployments.